### PR TITLE
Fixed exception for empty list of top prefixes

### DIFF
--- a/redis-faina.py
+++ b/redis-faina.py
@@ -53,10 +53,13 @@ class StatCounter(object):
     def _pretty_print(self, result, title):
         print title
         print '=' * 40
-        max_key_len = max((len(x[0]) for x in result))
-        for key, val in result:
-            key_padding = max(max_key_len - len(key), 0) * ' '
-            print key,key_padding,'\t',val
+        if len(result) > 0:
+            max_key_len = max((len(x[0]) for x in result))
+            for key, val in result:
+                key_padding = max(max_key_len - len(key), 0) * ' '
+                print key,key_padding,'\t',val
+        else:
+            print "n/a"
         print
 
     @staticmethod


### PR DESCRIPTION
I've got an exception for empty list of top prefixes:

```
Traceback (most recent call last):
  File "redis-faina.py", line 139, in <module>
    counter.print_stats()
  File "redis-faina.py", line 118, in print_stats
    self._pretty_print(self._top_n(self.prefixes), 'Top Prefixes')
  File "redis-faina.py", line 58, in _pretty_print
    max_key_len = max((len(x[0]) for x in result))
ValueError: max() arg is an empty sequence
```

so I fixed it. Now `_pretty_print` will use `n/a` placeholder for empty lists.

Btw, prefix should be configurable.
