### PR TITLE
Support running against redis servers where more than 1 db is used.

### DIFF
--- a/redis-faina.py
+++ b/redis-faina.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 import re
 
 line_re = re.compile(r"""
-    ^(?P<timestamp>[\d\.]+)\s"(?P<command>\w+)"(\s"(?P<key>[^(?<!\\)"]+)(?<!\\)")?(\s(?P<args>.+))?$
+    ^(?P<timestamp>[\d\.]+)\s(\(db\s(?P<db>\d*)\)\s)?"(?P<command>\w+)"(\s"(?P<key>[^(?<!\\)"]+)(?<!\\)")?(\s(?P<args>.+))?$
     """, re.VERBOSE)
 
 class StatCounter(object):


### PR DESCRIPTION
When running against my own production traffic, I found the script skipped most lines.
This is due to the "(db 1)" supplementary information output on each line of the monitor command output.
I updated the regex to match this.
